### PR TITLE
Feature/device info slider support

### DIFF
--- a/ParticleSDK/SDK/ParticleCloud.h
+++ b/ParticleSDK/SDK/ParticleCloud.h
@@ -88,6 +88,10 @@ typedef NS_ENUM(NSInteger, ParticleUpdateSimAction) {
  */
 @property (nonatomic, nullable, strong) NSString *oAuthClientSecret;
 
+
+@property (nonatomic, nullable, strong) NSString *customAPIBaseURL;
+@property (nonatomic, readonly) NSString *currentBaseURL;
+
 /**
  *  Singleton instance of ParticleCloud class
  *

--- a/ParticleSDK/SDK/ParticleCloud.m
+++ b/ParticleSDK/SDK/ParticleCloud.m
@@ -94,7 +94,11 @@ static NSString *const kDefaultoAuthClientSecret = @"particle";
         // init event listeners internal dictionary
         self.eventListenersDict = [NSMutableDictionary new];
 
-        [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"Has access token = %d", self.session.accessToken != nil];
+        #if DEBUG
+            [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"Has access token = %@", self.session.accessToken];
+        #else
+            [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"Has access token = %d", self.session.accessToken != nil];
+        #endif
 
         if (self.session.accessToken) {
             [self subscribeToDevicesSystemEvents];

--- a/ParticleSDK/SDK/ParticleDevice.h
+++ b/ParticleSDK/SDK/ParticleDevice.h
@@ -183,6 +183,11 @@ typedef NS_ENUM(NSInteger, ParticleDeviceNetworkRoleState) {
 
 
 /**
+ *  This will ping a device, enabling you to see if your device is online or offline
+ */
+- (NSURLSessionDataTask *)ping:(nullable void (^)(BOOL result, NSError *_Nullable error))completion;
+
+/**
  *  Request device refresh from cloud
  *  update online status/functions/variables/device name, etc
  *
@@ -198,10 +203,6 @@ typedef NS_ENUM(NSInteger, ParticleDeviceNetworkRoleState) {
  */
 -(NSURLSessionDataTask *)unclaim:(nullable ParticleCompletionBlock)completion;
 
-/*
--(void)compileAndFlash:(NSString *)sourceCode completion:(void(^)(NSError* error))completion;
--(void)flash:(NSData *)binary completion:(void(^)(NSError* error))completion;
-*/
 
 /**
  *  Rename device
@@ -210,6 +211,14 @@ typedef NS_ENUM(NSInteger, ParticleDeviceNetworkRoleState) {
  *  @param completion   Completion block called when function completes with NSError object in case of an error or nil if success.
  */
 -(NSURLSessionDataTask *)rename:(NSString *)newName completion:(nullable ParticleCompletionBlock)completion;
+
+/**
+ *  Edit device notes
+ *
+ *  @param notes        Notes to be associated with particular device
+ *  @param completion   Completion block called when function completes with NSError object in case of an error or nil if success.
+ */
+-(NSURLSessionDataTask *)setNotes:(NSString *)notes completion:(nullable ParticleCompletionBlock)completion;
 
 /**
  *  Retrieve current data usage report (For Electron only)

--- a/ParticleSDK/SDK/ParticleDevice.h
+++ b/ParticleSDK/SDK/ParticleDevice.h
@@ -131,8 +131,8 @@ typedef NS_ENUM(NSInteger, ParticleDeviceNetworkRoleState) {
 
 
 //new properties starting SDK v0.9.1
-@property (strong, nonatomic, nullable, readonly) NSString *serialNumber; // inactive
-@property (strong, nonatomic, nullable, readonly) NSString *mobileSecret; // inactive
+@property (strong, nonatomic, nullable, readonly) NSString *serialNumber;
+@property (strong, nonatomic, nullable, readonly) NSString *mobileSecret;
 
 /**
  *  Device firmware version string

--- a/ParticleSDK/SDK/ParticleDevice.h
+++ b/ParticleSDK/SDK/ParticleDevice.h
@@ -134,7 +134,7 @@ typedef NS_ENUM(NSInteger, ParticleDeviceNetworkRoleState) {
 @property (strong, nonatomic, nullable, readonly) NSString *serialNumber;
 @property (strong, nonatomic, nullable, readonly) NSString *mobileSecret;
 
-//new properties starting SDK v0.9.2
+//new properties starting SDK v0.9.6
 @property (strong, nonatomic, nullable) NSString *notes;
 @property (strong, nonatomic, readonly) NSString *systemFirmwareVersion;
 @property (nonatomic, readonly) BOOL cellular;

--- a/ParticleSDK/SDK/ParticleDevice.h
+++ b/ParticleSDK/SDK/ParticleDevice.h
@@ -134,10 +134,14 @@ typedef NS_ENUM(NSInteger, ParticleDeviceNetworkRoleState) {
 @property (strong, nonatomic, nullable, readonly) NSString *serialNumber;
 @property (strong, nonatomic, nullable, readonly) NSString *mobileSecret;
 
+//new properties starting SDK v0.9.2
+@property (strong, nonatomic, nullable) NSString *notes;
+@property (strong, nonatomic, readonly) NSString *systemFirmwareVersion;
+@property (nonatomic, readonly) BOOL cellular;
 /**
  *  Device firmware version string
  */
-@property (strong, nonatomic, readonly) NSString *version; // inactive
+
 @property (nonatomic, readonly) BOOL requiresUpdate;
 @property (nonatomic, readonly) ParticleDeviceType type;
 @property (nonatomic, readonly) NSString *typeString;

--- a/ParticleSDK/SDK/ParticleDevice.m
+++ b/ParticleSDK/SDK/ParticleDevice.m
@@ -52,7 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
     static dispatch_once_t onceToken;
     static AFHTTPSessionManager *manager = nil;
     dispatch_once(&onceToken, ^{
-        manager = [[AFHTTPSessionManager alloc] initWithBaseURL:[NSURL URLWithString:kParticleAPIBaseURL]];
+        manager = [[AFHTTPSessionManager alloc] initWithBaseURL:[NSURL URLWithString:ParticleCloud.sharedInstance.currentBaseURL]];
         manager.responseSerializer = [AFJSONResponseSerializer serializer];
     });
 
@@ -85,7 +85,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init])
     {
-        _baseURL = [NSURL URLWithString:kParticleAPIBaseURL];
+        _baseURL = [NSURL URLWithString:ParticleCloud.sharedInstance.currentBaseURL];
         if (!_baseURL) {
             return nil;
         }

--- a/ParticleSDK/SDK/ParticleDevice.m
+++ b/ParticleSDK/SDK/ParticleDevice.m
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) BOOL connected; // might be impossible
 @property (strong, nonatomic, nonnull) NSArray *functions;
 @property (strong, nonatomic, nonnull) NSDictionary *variables;
-@property (strong, nonatomic, nullable) NSString *version;
+@property (strong, nonatomic, nullable) NSString *systemFirmwareVersion;
 //@property (nonatomic) ParticleDeviceType type;
 @property (nonatomic) BOOL requiresUpdate;
 @property (nonatomic) BOOL isFlashing;
@@ -99,6 +99,7 @@ NS_ASSUME_NONNULL_BEGIN
         }
         
         _connected = [params[@"connected"] boolValue] == YES;
+        _cellular = [params[@"cellular"] boolValue] == YES;
         
         _functions = params[@"functions"] ?: @[];
         _variables = params[@"variables"] ?: @{};
@@ -180,6 +181,16 @@ NS_ASSUME_NONNULL_BEGIN
         if ([params[@"last_app"] isKindOfClass:[NSString class]])
         {
             _lastApp = params[@"last_app"];
+        }
+
+        if ((params[@"notes"]) && ([params[@"notes"] isKindOfClass:[NSString class]]))
+        {
+            _notes = params[@"notes"];
+        }
+
+        if ((params[@"system_firmware_version"]) && ([params[@"system_firmware_version"] isKindOfClass:[NSString class]]))
+        {
+            _systemFirmwareVersion = params[@"system_firmware_version"];
         }
 
         if ([params[@"last_heard"] isKindOfClass:[NSString class]])
@@ -514,7 +525,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     }
 
-    NSString *desc = [NSString stringWithFormat:@"<ParticleDevice 0x%lx, type: %@, id: %@, name: %@, connected: %@, flashing: %@, variables: %@, functions: %@, version: %@, requires update: %@, last app: %@, last heard: %@>",
+    NSString *desc = [NSString stringWithFormat:@"<ParticleDevice 0x%lx, type: %@, id: %@, name: %@, connected: %@, flashing: %@, variables: %@, functions: %@, version: %@, requires update: %@, last app: %@, last heard: %@, notes: %@>",
                       (unsigned long)self,
                       self.typeString,
                       self.id,
@@ -523,10 +534,11 @@ NS_ASSUME_NONNULL_BEGIN
                       (self.isFlashing) ? @"true" : @"false",
                       self.variables,
                       self.functions,
-                      self.version,
+                      self.systemFirmwareVersion,
                       (self.requiresUpdate) ? @"true" : @"false",
                       self.lastApp,
-                      self.lastHeard];
+                      self.lastHeard,
+                      self.notes];
     
     return desc;
     

--- a/ParticleSDK/SDK/ParticleDevice.m
+++ b/ParticleSDK/SDK/ParticleDevice.m
@@ -770,6 +770,14 @@ NS_ASSUME_NONNULL_BEGIN
                 [self.delegate particleDevice:self didReceiveSystemEvent:ParticleDeviceSystemEventFlashSucceeded];
             }
         }
+
+        if ([event.data containsString:@"failed"]) {
+            self.connected = YES;
+            self.isFlashing = NO;
+            if ([self.delegate respondsToSelector:@selector(particleDevice:didReceiveSystemEvent:)]) {
+                [self.delegate particleDevice:self didReceiveSystemEvent:ParticleDeviceSystemEventFlashFailed];
+            }
+        }
     }
     
     

--- a/ParticleSDK/SDK/ParticleDevice.m
+++ b/ParticleSDK/SDK/ParticleDevice.m
@@ -204,16 +204,6 @@ NS_ASSUME_NONNULL_BEGIN
             _lastHeard = [formatter dateFromString:dateString];
         }
 
-        /// WIP
-        /*
-        if (params[@"cc3000_patch_version"]) { // Core only
-            self.systemFirmwareVersion = (params[@"cc3000_patch_version"]);
-        } else if (params[@"current_build_target"]) { // Electron only
-            self.systemFirmwareVersion = params[@"current_build_target"];
-        }
-         */
-        
-            
         if (params[@"device_needs_update"])
         {
             _requiresUpdate = YES;

--- a/ParticleSDK/SDK/ParticleNetwork.m
+++ b/ParticleSDK/SDK/ParticleNetwork.m
@@ -32,7 +32,7 @@
 {
     if (self = [super init])
     {
-        _baseURL = [NSURL URLWithString:kParticleAPIBaseURL];
+        _baseURL = [NSURL URLWithString:ParticleCloud.sharedInstance.currentBaseURL];
         if (!_baseURL) {
             return nil;
         }


### PR DESCRIPTION
This PR introduces the following changes:
* Added support for editing device notes and pinging the device

* Added support for custom ParticleCloud API base URL

* Added support for `ParticleDeviceSystemEventFlashFailed` event

!!! Potentially breaking change !!!
* Preciusly unused `version` property has been renamed to `systemFirmwareVersion` and now it contains DeviceOS version string.