### PR TITLE
always log just last 4 characters of access token

### DIFF
--- a/ParticleSDK/SDK/ParticleCloud.m
+++ b/ParticleSDK/SDK/ParticleCloud.m
@@ -106,11 +106,7 @@ static NSString *const kDefaultoAuthClientSecret = @"particle";
         // init event listeners internal dictionary
         self.eventListenersDict = [NSMutableDictionary new];
 
-        #if DEBUG
-            [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"Has access token = %@", self.session.accessToken];
-        #else
-            [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"Has access token = %d", self.session.accessToken != nil];
-        #endif
+        [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"Access Token: ...%@", [self.session.accessToken substringFromIndex: [self.session.accessToken length] - 4]];
 
         if (self.session.accessToken) {
             [self subscribeToDevicesSystemEvents];


### PR DESCRIPTION
This PR changes logging behavior in SDK. It will now always log last 4 characters of access token instead of logging either everything or nothing based on build type.