### PR TITLE
make keychain values accessible in the background (requires iphone to be unlocked after reboot).

### DIFF
--- a/ParticleSDK/Helpers/KeychainHelper.m
+++ b/ParticleSDK/Helpers/KeychainHelper.m
@@ -47,6 +47,7 @@
 
     //add new value if one is provided
     if (value) {
+        [query setObject:(__bridge id)kSecAttrAccessibleAfterFirstUnlock forKey:(__bridge id)kSecAttrAccessible];
         [query setObject:[value dataUsingEncoding:NSUTF8StringEncoding] forKey:(__bridge id<NSCopying>)(kSecValueData)];
         OSStatus err = SecItemAdd((__bridge CFDictionaryRef)query, nil);
         if (err != noErr) {


### PR DESCRIPTION
This PR introduced hypothetical fix for a crash when trying to resume url session when app is running in the background. 