### PR TITLE
Feature/update afnetworking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 Particle iOS Cloud SDK adheres to [Semantic Versioning](http://semver.org/).
 
 ---
+## [1.0.5](https://github.com/particle-iot/particle-cloud-sdk-ios/releases/tag/1.0.5) (2020-04-17)
+
+* Update AFNetworking to 4.0 to fix AppStore error about usage of deprecated UIWebView
+
 ## [1.0.4](https://github.com/particle-iot/particle-cloud-sdk-ios/releases/tag/1.0.4) (2020-03-23)
 
 * Add custom header to easier identify traffic coming from mobile SDK

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 Particle iOS Cloud SDK adheres to [Semantic Versioning](http://semver.org/).
 
 ---
-## [1.0.5](https://github.com/particle-iot/particle-cloud-sdk-ios/releases/tag/1.0.5) (2020-04-17)
+## [1.0.5](https://github.com/particle-iot/particle-cloud-sdk-ios/releases/tag/1.0.5) (2020-04-24)
 
 * Update AFNetworking to 4.0 to fix AppStore error about usage of deprecated UIWebView
 

--- a/Particle-SDK.podspec
+++ b/Particle-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = "Particle-SDK"
-    s.version          = "1.0.4"
+    s.version          = "1.0.5"
     s.summary          = "Particle iOS Cloud SDK for interacting with Particle powered devices"
     s.description      = <<-DESC
                         Particle iOS Cloud SDK Cocoapod library

--- a/Particle-SDK.podspec
+++ b/Particle-SDK.podspec
@@ -22,13 +22,13 @@ Pod::Spec.new do |s|
 
     s.subspec 'Helpers' do |ss|
         ss.source_files = 'ParticleSDK/Helpers/*.{h,m}'
-        ss.dependency 'AFNetworking', '~> 3.0'
+        ss.dependency 'AFNetworking', '~> 4.0'
         ss.ios.frameworks = 'SystemConfiguration', 'Security'
     end
 
     s.subspec 'SDK' do |ss|
         ss.source_files = 'ParticleSDK/SDK/Particle*.{h,m}'
-        ss.dependency 'AFNetworking', '~> 3.0'
+        ss.dependency 'AFNetworking', '~> 4.0'
         ss.dependency 'Particle-SDK/Helpers'
     end
 

--- a/Particle-SDK.podspec
+++ b/Particle-SDK.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     s.source           = { :git => "https://github.com/particle-iot/particle-cloud-sdk-ios.git", :tag => s.version.to_s }
     s.social_media_url = 'https://twitter.com/particle'
 
-    s.platform     = :ios, '8.0'
+    s.platform     = :ios, '9.0'
     s.requires_arc = true
 
     s.public_header_files = 'ParticleSDK/*.h'

--- a/ParticleSDK/Helpers/EventSource.m
+++ b/ParticleSDK/Helpers/EventSource.m
@@ -127,13 +127,15 @@ static NSString *const ESEventEventKey = @"event";
         return;
     }
 
-    wasClosed = YES;
-
     dispatch_after(DISPATCH_TIME_NOW, self.queue, ^(void) {
-        [self.eventSource cancel];
-    });
+        if (wasClosed) {
+            return;
+        }
 
-    self.queue = nil;
+        [self.eventSource cancel];
+        self.queue = nil;
+        wasClosed = YES;
+    });
 }
 
 

--- a/ParticleSDK/SDK/ParticleCloud.m
+++ b/ParticleSDK/SDK/ParticleCloud.m
@@ -241,7 +241,7 @@ static NSString *const kDefaultoAuthClientSecret = @"particle";
     [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"POST %@, params = %@", @"oauth/token", params];
 
     // OAuth login
-    [self.manager POST:@"oauth/token" parameters:params progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
+    [self.manager POST:@"oauth/token" parameters:params headers:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
         [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"%@ (%i)", @"oauth/token", (int)((NSHTTPURLResponse *)task.response).statusCode];
         [ParticleLogger logDebug:NSStringFromClass([self class]) format:@"%@", responseObject];
 
@@ -281,7 +281,7 @@ static NSString *const kDefaultoAuthClientSecret = @"particle";
     [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"POST %@", @"oauth/token"];
 
     // OAuth login
-    NSURLSessionDataTask *task = [self.manager POST:@"oauth/token" parameters:params progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
+    NSURLSessionDataTask *task = [self.manager POST:@"oauth/token" parameters:params headers:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
         [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"%@ (%i)", @"oauth/token", (int)((NSHTTPURLResponse *)task.response).statusCode];
         NSMutableDictionary *responseDict = [responseObject mutableCopy];
 
@@ -325,7 +325,7 @@ static NSString *const kDefaultoAuthClientSecret = @"particle";
     [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"POST %@, params = %@", @"oauth/token", params];
 
     [self.manager.requestSerializer setAuthorizationHeaderFieldWithUsername:self.oAuthClientId password:self.oAuthClientSecret];
-    NSURLSessionDataTask *task = [self.manager POST:@"oauth/token" parameters:params progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
+    NSURLSessionDataTask *task = [self.manager POST:@"oauth/token" parameters:params headers:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
         [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"%@ (%i)", @"oauth/token", (int)((NSHTTPURLResponse *)task.response).statusCode];
 
         NSMutableDictionary *responseDict = [responseObject mutableCopy];
@@ -378,7 +378,7 @@ static NSString *const kDefaultoAuthClientSecret = @"particle";
     }
 
     [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"POST %@", @"/v1/users/"];
-    NSURLSessionDataTask *task = [self.manager POST:@"/v1/users/" parameters:params progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
+    NSURLSessionDataTask *task = [self.manager POST:@"/v1/users/" parameters:params headers:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
                                   {
                                       [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"%@ (%i)", @"/v1/users/", (int)((NSHTTPURLResponse *)task.response).statusCode];
                                       NSDictionary *responseDict = responseObject;
@@ -469,7 +469,7 @@ static NSString *const kDefaultoAuthClientSecret = @"particle";
 
     [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"POST %@", url];
 
-    NSURLSessionDataTask *task = [self.manager POST:url parameters:params progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
+    NSURLSessionDataTask *task = [self.manager POST:url parameters:params headers:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
                                   {
                                       [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"%@ (%i)", url, (int)((NSHTTPURLResponse *)task.response).statusCode];
 
@@ -544,7 +544,7 @@ static NSString *const kDefaultoAuthClientSecret = @"particle";
 
     [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"POST %@, params = %@", @"/v1/devices", params];
     
-    NSURLSessionDataTask *task = [self.manager POST:@"/v1/devices" parameters:params progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
+    NSURLSessionDataTask *task = [self.manager POST:@"/v1/devices" parameters:params headers:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
     {
         [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"%@ (%i)", @"/v1/devices", (int)((NSHTTPURLResponse *)task.response).statusCode];
         [ParticleLogger logDebug:NSStringFromClass([self class]) format:@"%@", responseObject];
@@ -591,7 +591,7 @@ static NSString *const kDefaultoAuthClientSecret = @"particle";
     NSString *urlPath = [NSString stringWithFormat:@"/v1/devices/%@",deviceID];
     [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"GET %@", urlPath];
 
-    NSURLSessionDataTask *task = [self.manager GET:urlPath parameters:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
+    NSURLSessionDataTask *task = [self.manager GET:urlPath parameters:nil headers:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
     {
         [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"%@ (%i)", urlPath, (int)((NSHTTPURLResponse *)task.response).statusCode];
         [ParticleLogger logComplete:NSStringFromClass([self class]) format:@"%@", responseObject];
@@ -637,7 +637,7 @@ static NSString *const kDefaultoAuthClientSecret = @"particle";
     }
 
     [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"GET %@", @"/v1/devices"];
-    NSURLSessionDataTask *task = [self.manager GET:@"/v1/devices" parameters:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
+    NSURLSessionDataTask *task = [self.manager GET:@"/v1/devices" parameters:nil headers:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
     {
         [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"%@ (%i)", @"/v1/devices", (int)((NSHTTPURLResponse *)task.response).statusCode];
         [ParticleLogger logComplete:NSStringFromClass([self class]) format:@"%@", responseObject];
@@ -694,7 +694,7 @@ static NSString *const kDefaultoAuthClientSecret = @"particle";
 
     [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"POST %@", urlPath];
 
-    NSURLSessionDataTask *task = [self.manager POST:urlPath parameters:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
+    NSURLSessionDataTask *task = [self.manager POST:urlPath parameters:nil headers:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
     {
         [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"%@ (%i)", urlPath, (int)((NSHTTPURLResponse *)task.response).statusCode];
         [ParticleLogger logDebug:NSStringFromClass([self class]) format:@"%@", responseObject];
@@ -762,7 +762,7 @@ static NSString *const kDefaultoAuthClientSecret = @"particle";
 
     [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"POST %@", @"/v1/products/%tu/device_claims"];
 
-    NSURLSessionDataTask *task = [self.manager POST:urlPath parameters:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
+    NSURLSessionDataTask *task = [self.manager POST:urlPath parameters:nil headers:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
                                   {
                                       [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"%@ (%i)", @"/v1/products/%tu/device_claims", (int)((NSHTTPURLResponse *)task.response).statusCode];
                                       [ParticleLogger logDebug:NSStringFromClass([self class]) format:@"%@", responseObject];
@@ -816,7 +816,8 @@ static NSString *const kDefaultoAuthClientSecret = @"particle";
 
     [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"%POST @, params = %@", urlPath, params];
 
-    NSURLSessionDataTask *task = [self.manager POST:urlPath parameters:params progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
+
+    NSURLSessionDataTask *task = [self.manager POST:urlPath parameters:params headers:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
     {
         [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"%@ (%i)", urlPath, (int)((NSHTTPURLResponse *)task.response).statusCode];
         [ParticleLogger logDebug:NSStringFromClass([self class]) format:@"%@", responseObject];
@@ -864,7 +865,7 @@ static NSString *const kDefaultoAuthClientSecret = @"particle";
     [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"GET %@, params = %@", url.absoluteString, params];
 
 
-    NSURLSessionDataTask *task = [self.manager GET:[url description] parameters:params progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
+    NSURLSessionDataTask *task = [self.manager GET:[url description] parameters:params headers:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
     {
         [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"%@ (%i)", url.absoluteString, (int)((NSHTTPURLResponse *)task.response).statusCode];
         [ParticleLogger logDebug:NSStringFromClass([self class]) format:@"%@", responseObject];
@@ -939,7 +940,7 @@ static NSString *const kDefaultoAuthClientSecret = @"particle";
 
     [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"GET %@", @"/v1/access_tokens"];
 
-    NSURLSessionDataTask *task = [self.manager GET:@"/v1/access_tokens" parameters:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
+    NSURLSessionDataTask *task = [self.manager GET:@"/v1/access_tokens" parameters:nil headers:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
     {
         [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"%@ (%i)", @"/v1/access_tokens", (int)((NSHTTPURLResponse *)task.response).statusCode];
         [ParticleLogger logDebug:NSStringFromClass([self class]) format:@"%@", responseObject];
@@ -1126,7 +1127,7 @@ static NSString *const kDefaultoAuthClientSecret = @"particle";
 
     [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"POST %@, params = %@", @"/v1/devices/events", params];
 
-    NSURLSessionDataTask *task = [self.manager POST:@"/v1/devices/events" parameters:params progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
+    NSURLSessionDataTask *task = [self.manager POST:@"/v1/devices/events" parameters:params headers:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
     {
         [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"%@ (%i)", @"/v1/devices/events", (int)((NSHTTPURLResponse *)task.response).statusCode];
         [ParticleLogger logDebug:NSStringFromClass([self class]) format:@"%@", responseObject];
@@ -1198,7 +1199,7 @@ static NSString *const kDefaultoAuthClientSecret = @"particle";
 
     [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"%@", @"GET /v1/card"];
 
-    NSURLSessionDataTask *task = [self.manager GET:@"/v1/card" parameters:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
+    NSURLSessionDataTask *task = [self.manager GET:@"/v1/card" parameters:nil headers:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
                                   {
                                       [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"%@ (%i)", @"/v1/card", (int)((NSHTTPURLResponse *)task.response).statusCode];
                                       [ParticleLogger logDebug:NSStringFromClass([self class]) format:@"%@", responseObject];
@@ -1255,7 +1256,7 @@ static NSString *const kDefaultoAuthClientSecret = @"particle";
 
     [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"GET %@", @"/v1/networks"];
 
-    NSURLSessionDataTask *task = [self.manager GET:@"/v1/networks" parameters:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
+    NSURLSessionDataTask *task = [self.manager GET:@"/v1/networks" parameters:nil headers:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
                                   {
                                       [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"%@ (%i)", @"/v1/networks", (int)((NSHTTPURLResponse *)task.response).statusCode];
                                       [ParticleLogger logDebug:NSStringFromClass([self class]) format:@"%@", responseObject];
@@ -1317,7 +1318,7 @@ static NSString *const kDefaultoAuthClientSecret = @"particle";
 
     [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"GET %@", endpoint];
 
-    NSURLSessionDataTask *task = [self.manager GET:endpoint parameters:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
+    NSURLSessionDataTask *task = [self.manager GET:endpoint parameters:nil headers:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
                                   {
                                       [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"%@ (%i)", endpoint, (int)((NSHTTPURLResponse *)task.response).statusCode];
                                       [ParticleLogger logDebug:NSStringFromClass([self class]) format:@"%@", responseObject];
@@ -1366,7 +1367,7 @@ static NSString *const kDefaultoAuthClientSecret = @"particle";
 
     [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"GET %@", endpoint];
 
-    NSURLSessionDataTask *task = [self.manager GET:endpoint parameters:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
+    NSURLSessionDataTask *task = [self.manager GET:endpoint parameters:nil headers:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
                                   {
                                       [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"%@ (%i)", endpoint, (int)((NSHTTPURLResponse *)task.response).statusCode];
                                       [ParticleLogger logDebug:NSStringFromClass([self class]) format:@"%@", responseObject];
@@ -1414,7 +1415,7 @@ static NSString *const kDefaultoAuthClientSecret = @"particle";
 
     [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"GET %@", endpoint];
 
-    NSURLSessionDataTask *task = [self.manager GET:endpoint parameters:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
+    NSURLSessionDataTask *task = [self.manager GET:endpoint parameters:nil headers:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
     {
         [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"%@ (%i)", endpoint, (int)((NSHTTPURLResponse *)task.response).statusCode];
         [ParticleLogger logDebug:NSStringFromClass([self class]) format:@"%@", responseObject];
@@ -1494,7 +1495,7 @@ static NSString *const kDefaultoAuthClientSecret = @"particle";
 
     [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"POST %@, params = %@", @"/v1/networks/", params];
 
-    NSURLSessionDataTask *task = [self.manager POST:@"/v1/networks/" parameters:params progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
+    NSURLSessionDataTask *task = [self.manager POST:@"/v1/networks/" parameters:params headers:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
                                   {
                                       [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"%@ (%i)", @"/v1/networks/", (int)((NSHTTPURLResponse *)task.response).statusCode];
                                       [ParticleLogger logDebug:NSStringFromClass([self class]) format:@"%@", responseObject];
@@ -1550,7 +1551,7 @@ static NSString *const kDefaultoAuthClientSecret = @"particle";
 
     [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"PUT %@, params = %@", @"/v1/card/", params];
 
-    NSURLSessionDataTask *task = [self.manager PUT:@"/v1/card/" parameters:params success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
+    NSURLSessionDataTask *task = [self.manager PUT:@"/v1/card/" parameters:params headers:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
     {
         [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"%@ (%i)", @"/v1/card/", (int)((NSHTTPURLResponse *)task.response).statusCode];
         [ParticleLogger logDebug:NSStringFromClass([self class]) format:@"%@", responseObject];
@@ -1585,7 +1586,7 @@ static NSString *const kDefaultoAuthClientSecret = @"particle";
     [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"GET %@", url];
 
 
-    NSURLSessionDataTask *task = [self.manager GET:[url description] parameters:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
+    NSURLSessionDataTask *task = [self.manager GET:[url description] parameters:nil headers:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
     {
         [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"%@ (%i)", url, (int)((NSHTTPURLResponse *)task.response).statusCode];
         [ParticleLogger logDebug:NSStringFromClass([self class]) format:@"%@", responseObject];
@@ -1623,7 +1624,8 @@ static NSString *const kDefaultoAuthClientSecret = @"particle";
 
     [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"HEAD %@", url];
 
-    NSURLSessionDataTask *task = [self.manager HEAD:url parameters:nil success:^(NSURLSessionDataTask * _Nonnull task)
+
+    NSURLSessionDataTask *task = [self.manager HEAD:url parameters:nil headers:nil success:^(NSURLSessionDataTask * _Nonnull task)
                                   {
                                       [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"%@ (%i)", url, (int)((NSHTTPURLResponse *)task.response).statusCode];
 
@@ -1756,7 +1758,7 @@ static NSString *const kDefaultoAuthClientSecret = @"particle";
 
     [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"PUT %@, params = %@", url, params];
 
-    NSURLSessionDataTask *task = [self.manager PUT:url parameters:params success:^(NSURLSessionDataTask * _Nonnull task, id _Nullable responseObject)
+    NSURLSessionDataTask *task = [self.manager PUT:url parameters:params headers:nil success:^(NSURLSessionDataTask * _Nonnull task, id _Nullable responseObject)
                                   {
                                       [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"%@ (%i)", url, (int)((NSHTTPURLResponse *)task.response).statusCode];
                                       [ParticleLogger logDebug:NSStringFromClass([self class]) format:@"%@", responseObject];
@@ -1809,7 +1811,7 @@ static NSString *const kDefaultoAuthClientSecret = @"particle";
 
     [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"PUT %@, params = %@", url, params];
 
-    NSURLSessionDataTask *task = [self.manager PUT:url parameters:params success:^(NSURLSessionDataTask * _Nonnull task, id _Nullable responseObject)
+    NSURLSessionDataTask *task = [self.manager PUT:url parameters:params headers:nil success:^(NSURLSessionDataTask * _Nonnull task, id _Nullable responseObject)
     {
         [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"%@ (%i)", url, (int)((NSHTTPURLResponse *)task.response).statusCode];
         [ParticleLogger logDebug:NSStringFromClass([self class]) format:@"%@", responseObject];
@@ -1892,7 +1894,7 @@ static NSString *const kDefaultoAuthClientSecret = @"particle";
 
     [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"DELETE %@", urlPath];
 
-    NSURLSessionDataTask *task = [self.manager DELETE:urlPath parameters:nil success:^(NSURLSessionDataTask *task, id responseObject)
+    NSURLSessionDataTask *task = [self.manager DELETE:urlPath parameters:nil headers:nil success:^(NSURLSessionDataTask *task, id responseObject)
     {
         [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"%@ (%i)", urlPath, (int)((NSHTTPURLResponse *)task.response).statusCode];
         [ParticleLogger logDebug:NSStringFromClass([self class]) format:@"%@", responseObject];
@@ -1962,7 +1964,7 @@ static NSString *const kDefaultoAuthClientSecret = @"particle";
 
     [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"GET %@, params = %@", url.absoluteString, params];
 
-    NSURLSessionDataTask *task = [self.manager GET:[url description] parameters:params progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
+    NSURLSessionDataTask *task = [self.manager GET:[url description] parameters:params headers:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
                                   {
                                       [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"%@ (%i)", url.absoluteString, (int)((NSHTTPURLResponse *)task.response).statusCode];
                                       [ParticleLogger logDebug:NSStringFromClass([self class]) format:@"%@", responseObject];

--- a/ParticleSDK/SDK/ParticleDevice.m
+++ b/ParticleSDK/SDK/ParticleDevice.m
@@ -251,7 +251,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     [self setAuthHeaderWithAccessToken];
 
-    NSURLSessionDataTask *task = [ParticleDevice.manager PUT:[url description] parameters:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
+    NSURLSessionDataTask *task = [ParticleDevice.manager PUT:[url description] parameters:nil headers:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
         [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"%@ (%i)", url.absoluteString, (int)((NSHTTPURLResponse *)task.response).statusCode];
         [ParticleLogger logDebug:NSStringFromClass([self class]) format:@"%@", responseObject];
 
@@ -326,7 +326,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     [self setAuthHeaderWithAccessToken];
     
-    NSURLSessionDataTask *task = [ParticleDevice.manager GET:[url description] parameters:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
+    NSURLSessionDataTask *task = [ParticleDevice.manager GET:[url description] parameters:nil headers:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
     {
         [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"%@ (%i)", url.absoluteString, (int)((NSHTTPURLResponse *)task.response).statusCode];
         [ParticleLogger logDebug:NSStringFromClass([self class]) format:@"%@", responseObject];
@@ -392,7 +392,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     [self setAuthHeaderWithAccessToken];
     
-    NSURLSessionDataTask *task = [ParticleDevice.manager POST:[url description] parameters:params progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
+    NSURLSessionDataTask *task = [ParticleDevice.manager POST:[url description] parameters:params headers:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
     {
         [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"%@ (%i)", url.absoluteString, (int)((NSHTTPURLResponse *)task.response).statusCode];
         [ParticleLogger logDebug:NSStringFromClass([self class]) format:@"%@", responseObject];
@@ -439,7 +439,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     [self setAuthHeaderWithAccessToken];
 
-    NSURLSessionDataTask *task = [ParticleDevice.manager PUT:[url description] parameters:params success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
+    NSURLSessionDataTask *task = [ParticleDevice.manager PUT:[url description] parameters:params headers:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
         [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"%@ (%i)", url.absoluteString, (int)((NSHTTPURLResponse *)task.response).statusCode];
         [ParticleLogger logDebug:NSStringFromClass([self class]) format:@"%@", responseObject];
 
@@ -470,7 +470,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     [self setAuthHeaderWithAccessToken];
 
-    NSURLSessionDataTask *task = [ParticleDevice.manager DELETE:[url description] parameters:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
+    NSURLSessionDataTask *task = [ParticleDevice.manager DELETE:[url description] parameters:nil headers:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
     {
         [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"%@ (%i)", url.absoluteString, (int)((NSHTTPURLResponse *)task.response).statusCode];
         [ParticleLogger logDebug:NSStringFromClass([self class]) format:@"%@", responseObject];
@@ -519,7 +519,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     [self setAuthHeaderWithAccessToken];
 
-    NSURLSessionDataTask *task = [ParticleDevice.manager PUT:[url description] parameters:params success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
+    NSURLSessionDataTask *task = [ParticleDevice.manager PUT:[url description] parameters:params headers:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
         [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"%@ (%i)", url.absoluteString, (int)((NSHTTPURLResponse *)task.response).statusCode];
         [ParticleLogger logDebug:NSStringFromClass([self class]) format:@"%@", responseObject];
 
@@ -553,7 +553,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     [self setAuthHeaderWithAccessToken];
 
-    NSURLSessionDataTask *task = [ParticleDevice.manager PUT:[url description] parameters:params success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
+    NSURLSessionDataTask *task = [ParticleDevice.manager PUT:[url description] parameters:params headers:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject) {
         [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"%@ (%i)", url.absoluteString, (int)((NSHTTPURLResponse *)task.response).statusCode];
         [ParticleLogger logDebug:NSStringFromClass([self class]) format:@"%@", responseObject];
 
@@ -638,7 +638,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     [self setAuthHeaderWithAccessToken];
     
-    NSURLSessionDataTask *task = [ParticleDevice.manager PUT:[url description] parameters:params success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
+    NSURLSessionDataTask *task = [ParticleDevice.manager PUT:[url description] parameters:params headers:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
     {
         [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"%@ (%i)", url.absoluteString, (int)((NSHTTPURLResponse *)task.response).statusCode];
         [ParticleLogger logDebug:NSStringFromClass([self class]) format:@"%@", responseObject];
@@ -775,7 +775,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     [self setAuthHeaderWithAccessToken];
     
-    NSURLSessionDataTask *task = [ParticleDevice.manager GET:[url description] parameters:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
+    NSURLSessionDataTask *task = [ParticleDevice.manager GET:[url description] parameters:nil headers:nil progress:nil success:^(NSURLSessionDataTask * _Nonnull task, id  _Nullable responseObject)
                                   {
                                       [ParticleLogger logInfo:NSStringFromClass([self class]) format:@"%@ (%i)", url.absoluteString, (int)((NSHTTPURLResponse *)task.response).statusCode];
                                       [ParticleLogger logDebug:NSStringFromClass([self class]) format:@"%@", responseObject];

--- a/Podfile
+++ b/Podfile
@@ -4,18 +4,9 @@ source 'https://cdn.cocoapods.org/'
 platform :ios, '9.0'
 
 target 'ParticleSDKPods' do
-    pod 'AFNetworking/NSURLSession'
+    pod 'AFNetworking', '~> 4.0'
 
     target 'ParticleSDKTests' do
         pod 'OHHTTPStubs/Swift'
-    end
-end
-
-
-post_install do |pi|
-    pi.pods_project.targets.each do |t|
-        t.build_configurations.each do |config|
-            config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '8.0'
-        end
     end
 end

--- a/Podfile
+++ b/Podfile
@@ -1,7 +1,7 @@
 source 'https://cdn.cocoapods.org/'
 
 
-platform :ios, '8.0'
+platform :ios, '9.0'
 
 target 'ParticleSDKPods' do
     pod 'AFNetworking/NSURLSession'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,11 +1,19 @@
 PODS:
-  - AFNetworking/NSURLSession (3.2.1):
+  - AFNetworking (4.0.0):
+    - AFNetworking/NSURLSession (= 4.0.0)
+    - AFNetworking/Reachability (= 4.0.0)
+    - AFNetworking/Security (= 4.0.0)
+    - AFNetworking/Serialization (= 4.0.0)
+    - AFNetworking/UIKit (= 4.0.0)
+  - AFNetworking/NSURLSession (4.0.0):
     - AFNetworking/Reachability
     - AFNetworking/Security
     - AFNetworking/Serialization
-  - AFNetworking/Reachability (3.2.1)
-  - AFNetworking/Security (3.2.1)
-  - AFNetworking/Serialization (3.2.1)
+  - AFNetworking/Reachability (4.0.0)
+  - AFNetworking/Security (4.0.0)
+  - AFNetworking/Serialization (4.0.0)
+  - AFNetworking/UIKit (4.0.0):
+    - AFNetworking/NSURLSession
   - OHHTTPStubs/Core (8.0.0)
   - OHHTTPStubs/Default (8.0.0):
     - OHHTTPStubs/Core
@@ -21,7 +29,7 @@ PODS:
     - OHHTTPStubs/Default
 
 DEPENDENCIES:
-  - AFNetworking/NSURLSession
+  - AFNetworking (~> 4.0)
   - OHHTTPStubs/Swift
 
 SPEC REPOS:
@@ -30,9 +38,9 @@ SPEC REPOS:
     - OHHTTPStubs
 
 SPEC CHECKSUMS:
-  AFNetworking: b6f891fdfaed196b46c7a83cf209e09697b94057
+  AFNetworking: d9fdf484a3c723ec3c558a41cc5754c7e845ee77
   OHHTTPStubs: 9cbce6364bec557cc3439aa6bb7514670d780881
 
-PODFILE CHECKSUM: 7860238827a698a5fe8d564cb12f57b58fc30512
+PODFILE CHECKSUM: 84a10556255b654e3cc59f3a7c760f5b81dfdb92
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.9.1


### PR DESCRIPTION
This PR updates dependencies to remove the warning triggered by the underlying AFNetworking dependency that is being displayed when uploading the app that uses this SDK. Also this hopefully fixes a thread issue happening in EventSource. 